### PR TITLE
Enhance the Gitpod Web GHA

### DIFF
--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -23,8 +23,7 @@ jobs:
         with:
           node-version: 16
           cache: 'yarn'
-          cache-dependency-path: |
-            '**/yarn.lock'
+          cache-dependency-path: '**/yarn.lock'
       - name: Execute yarn
         run: |
           yarn --frozen-lockfile

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -45,7 +45,12 @@ jobs:
           echo "\`\`\`" >> summary.md
           cat summary.md >> $GITHUB_STEP_SUMMARY
 
+      - name: Get previous job's status
+        id: lastrun
+        uses: filiptronicek/get-last-job-status@main
+
       - name: Slack Notification
+        if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -24,7 +24,6 @@ jobs:
           node-version: 16
           cache: 'yarn'
           cache-dependency-path: |
-            'yarn.lock'
             '**/yarn.lock'
       - name: Execute yarn
         run: |

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Output the image tag to the GitHub Summary
         run: |
           echo "Successfully built the gitpod-web extension with the tag:" >> summary.md
-          echo "```md" >> summary.md
+          echo "" >> summary.md
+          echo "```" >> summary.md
           echo "commit-${{ github.sha }}" >> summary.md
           echo "```" >> summary.md
           cat summary.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -38,7 +38,7 @@ jobs:
           tags: eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-${{ github.sha }}
       - name: Output the image tag to the GitHub Summary
         run: |
-          echo "Successfully built the gitpod-web extension with the tag:" >> summary.md
+          echo "Successfully built the \`gitpod-web extension\` with the tag:" >> summary.md
           echo "" >> summary.md
           echo "\`\`\`" >> summary.md
           echo "commit-${{ github.sha }}" >> summary.md

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Auth Google Cloud SDK
         uses: google-github-actions/auth@v0
         with:
@@ -22,6 +22,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
+          cache: 'yarn'
+          cache-dependency-path: |
+            'yarn.lock'
+            '**/yarn.lock'
       - name: Execute yarn
         run: |
           yarn --frozen-lockfile
@@ -42,6 +46,7 @@ jobs:
           echo "commit-${{ github.sha }}" >> summary.md
           echo "```" >> summary.md
           cat summary.md >> $GITHUB_STEP_SUMMARY
+
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           echo "Successfully built the gitpod-web extension with the tag:" >> summary.md
           echo "" >> summary.md
-          echo "```" >> summary.md
+          echo "\`\`\`" >> summary.md
           echo "commit-${{ github.sha }}" >> summary.md
-          echo "```" >> summary.md
+          echo "\`\`\`" >> summary.md
           cat summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Slack Notification

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -1,6 +1,7 @@
 name: Gitpod-Web Docker
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build:
@@ -33,7 +34,13 @@ jobs:
           push: true
           context: gitpod-web
           tags: eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-${{ github.sha }}
-
+      - name: Output the image tag to the GitHub Summary
+        run: |
+          echo "Successfully built the gitpod-web extension with the tag:" >> summary.md
+          echo "```md" >> summary.md
+          echo "commit-${{ github.sha }}" >> summary.md
+          echo "```" >> summary.md
+          cat summary.md >> $GITHUB_STEP_SUMMARY
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:

--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -1,7 +1,6 @@
 name: Gitpod-Web Docker
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   build:


### PR DESCRIPTION
## Description
This PR changes the following:
- Adds the resulting Docker commit to the job summary, so it is easily accessible and copy-able from the GitHub Actions UI [[example](https://github.com/gitpod-io/gitpod-code/actions/runs/4103797354#summary-11136093056)]
- Adds Yarn cache, so that our build times improve by ~10 seconds
- Only posts to Slack on failure or when coming from a failing to a succeeding state
- Bump `actions/checkout` to remove deprecation warning
- **Runs the Job on every push for faster workflows**
