### PR TITLE
Fix remote server invocation

### DIFF
--- a/gitpod-remote/package.json
+++ b/gitpod-remote/package.json
@@ -3,7 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "gitpod",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "license": "MIT",
   "preview": true,
   "icon": "resources/gitpod.png",

--- a/gitpod-remote/src/remoteExtensionInit.ts
+++ b/gitpod-remote/src/remoteExtensionInit.ts
@@ -43,9 +43,11 @@ export async function initializeRemoteExtensions(extensions: ISyncExtension[], c
 	const codeCliPath = path.join(vscode.env.appRoot, 'bin/remote-cli', appName);
 	const args = extensions.map(e => '--install-extension ' + e.identifier.id).join(' ');
 
+	const execEnv = { ...process.env };
+	delete execEnv['ELECTRON_RUN_AS_NODE']
 	try {
-		context.logger.trace('Trying to initialize remote extensions:', extensions.map(e => e.identifier.id).join('\n'));
-		const { stderr } = await util.promisify(cp.exec)(`${codeCliPath} ${args}`);
+		context.logger.info('Trying to initialize remote extensions:', extensions.map(e => e.identifier.id).join('\n'));
+		const { stderr } = await util.promisify(cp.exec)(`${codeCliPath} ${args}`, { env: execEnv });
 		if (stderr) {
 			context.logger.error('Failed to initialize remote extensions:', stderr);
 		}
@@ -104,9 +106,11 @@ export async function installInitialExtensions(context: GitpodExtensionContext) 
 	const codeCliPath = path.join(vscode.env.appRoot, 'bin/remote-cli', appName);
 	const args = extensions.map(e => '--install-extension ' + e.toString()).join(' ');
 
+	const execEnv = { ...process.env };
+	delete execEnv['ELECTRON_RUN_AS_NODE']
 	try {
-		context.logger.trace('Trying to initialize remote extensions from gitpod.yml:', extensions.map(e => e.toString()).join('\n'));
-		const { stderr } = await util.promisify(cp.exec)(`${codeCliPath} ${args}`);
+		context.logger.info('Trying to initialize remote extensions from gitpod.yml:', extensions.map(e => e.toString()).join('\n'));
+		const { stderr } = await util.promisify(cp.exec)(`${codeCliPath} ${args}`, { env: execEnv });
 		if (stderr) {
 			context.logger.error('Failed to initialize remote extensions from gitpod.yml:', stderr);
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
vscode 1.92 has a regression and doesn't remove `ELECTRON_RUN_AS_NODE` properly

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
