### PR TITLE
Update README and package description for Gitpod Classic extension clarity

### DIFF
--- a/gitpod-remote/README.md
+++ b/gitpod-remote/README.md
@@ -1,31 +1,7 @@
 # Gitpod Classic Remote
 
-> **Note**: If you’re looking for the [Gitpod Flex](https://app.gitpod.io) experience, please install the [Gitpod Flex extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-flex). For [Gitpod Classic](https://gitpod.io/workspaces) workspaces, this is the extension you need.
+> **Note**: If you’re looking for the [Gitpod Flex](https://app.gitpod.io) experience, please install the [Gitpod Flex extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-flex).
 
-Gitpod is an open-source Kubernetes application for automated and ready-to-code development environments that blends in your existing workflow. It enables you to describe your dev environment as code and start instant and fresh development environments for each new task directly from your browser.
+This extension is automatically installed in Gitpod Classic workspaces. It provides the Gitpod Classic experience in Visual Studio Code. It is required to provision extension, task terminals, etc.
 
-Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and continuously prebuilds dev environments for all your branches. As a result, team members can instantly start coding with fresh, ephemeral and fully-compiled dev environments - no matter if you are building a new feature, want to fix a bug or do a code review.
-
-![image](https://user-images.githubusercontent.com/120486/116072013-40a8aa00-a697-11eb-846b-89e6f5e1a82e.png)
-
-## Getting Started
-
-[Start a new Gitpod workspace](https://www.gitpod.io/docs/getting-started) and use F1 -> `Open in VS Code` command to connect to it from VS Code Desktop.
-
-## Documentation
-
-All documentation can be found on https://www.gitpod.io/docs.
-For example, see [Introduction](https://www.gitpod.io/docs) and [Getting Started](https://www.gitpod.io/docs/getting-started) sections. 📚
-
-## Questions
-
-For questions and support please use the [community forum](http://community.gitpod.io) or the [community discord server](https://www.gitpod.io/chat).
-Join the conversation, and connect with other community members. 💬
-
-You can also follow [`@gitpod`](https://twitter.com/gitpod) for announcements and updates from our team.
-
-## Issues
-
-The issue tracker is used for tracking **bug reports** and **feature requests** for the Gitpod open source project as well as planning current and future development efforts. 🗺️
-
-You can upvote [popular feature requests](https://github.com/gitpod-io/gitpod/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) or [create a new one](https://github.com/gitpod-io/gitpod/issues/new?template=feature_request.md).
+If you need Gitpod Classic workspaces, you can use the [Gitpod Classic extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-desktop) to create & manage them.

--- a/gitpod-remote/README.md
+++ b/gitpod-remote/README.md
@@ -2,6 +2,8 @@
 
 > **Note**: If you’re looking for the [Gitpod Flex](https://app.gitpod.io) experience, please install the [Gitpod Flex extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-flex).
 
-This extension is automatically installed in Gitpod Classic workspaces. It provides the Gitpod Classic experience in Visual Studio Code. It is required to provision extension, task terminals, etc.
+This extension is automatically installed in [Gitpod Classic workspaces](https://gitpod.io/workspaces). It is required to provision extension, task terminals, etc.
 
-If you need Gitpod Classic workspaces, you can use the [Gitpod Classic extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-desktop) to create & manage them.
+If you need Gitpod Classic workspaces, you should use the [Gitpod Classic extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-desktop).
+
+This extension is automatically installed by [Gitpod Classic extension](https://marketplace.visualstudio.com/items?itemName=gitpod.gitpod-desktop) inside workspaces in order to provision extensions, task terminals, etc. You should not install this extension manually.

--- a/gitpod-remote/package.nls.json
+++ b/gitpod-remote/package.nls.json
@@ -1,6 +1,6 @@
 {
 	"displayName": "Gitpod Remote",
-	"description": "Gitpod Remote Support",
+	"description": "Auto-installed within Classic workspaces, required to provision extensions, task terminals, etc.",
 	"openDashboard": "Gitpod: Open Dashboard",
 	"openAccessControl": "Gitpod: Open Access Control",
 	"openSettings": "Gitpod: Open Settings",


### PR DESCRIPTION
Clarify the purpose and functionality of the Gitpod Classic extension in the README and update the package description to reflect its automatic installation and requirements.

Part of [Related conversation](https://gitpod.slack.com/archives/C06C23ZTFL6/p1731339460372149?thread_ts=1730981493.776589&cid=C06C23ZTFL6)