### PR TITLE
Disable npm lifecycle scripts and npx for security

### DIFF
--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Execute yarn
         run: |
-          yarn --frozen-lockfile
+          yarn --frozen-lockfile --ignore-scripts
 
       - name: Update Segment
         working-directory: ./gitpod-web

--- a/.github/workflows/release-gitpod-remote.yml
+++ b/.github/workflows/release-gitpod-remote.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn install --frozen-lockfile
+          yarn install --frozen-lockfile --ignore-scripts
 
       - name: Update Segment
         working-directory: ./gitpod-remote
@@ -40,13 +40,13 @@ jobs:
       - name: Publish to MS Marketplace
         working-directory: ./gitpod-remote
         run: |
-          npx vsce publish --packagePath ${{ steps.package_vsix.outputs.vsix_path }}
+          yarn vsce publish --packagePath ${{ steps.package_vsix.outputs.vsix_path }}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Publish to Open VSX Registry
         working-directory: ./gitpod-remote
         run: |
-          npx ovsx publish --packagePath ${{ steps.package_vsix.outputs.vsix_path }}
+          yarn ovsx publish --packagePath ${{ steps.package_vsix.outputs.vsix_path }}
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_PAT }}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 image: gitpod/workspace-node
 tasks:
   - init: |
-      yarn install
+      yarn install --ignore-scripts
     name: Compile gitpod-shared
     command: |
       cd gitpod-shared

--- a/gitpod-remote/package.json
+++ b/gitpod-remote/package.json
@@ -359,9 +359,11 @@
     "build:webview": "node esbuild.js",
     "watch:webview": "node esbuild.js --watch",
     "start:webview": "sirv public --no-clear",
-    "package": "npx vsce package --yarn --allow-star-activation"
+    "package": "yarn vsce package --yarn --allow-star-activation"
   },
   "devDependencies": {
+    "@vscode/vsce": "^2.22.0",
+    "ovsx": "^0.8.3",
     "@tsconfig/svelte": "^2.0.0",
     "@types/node": "16.x",
     "@types/vscode": "1.75.0",

--- a/gitpod-web/package.json
+++ b/gitpod-web/package.json
@@ -563,10 +563,12 @@
     "build:webview": "node esbuild.js",
     "watch:webview": "node esbuild.js --watch",
     "start:webview": "sirv public --no-clear",
-    "update-dts": "cd \"src/@types\" && npx vscode-dts dev",
-    "package": "npx vsce package --yarn --allow-star-activation"
+    "update-dts": "cd \"src/@types\" && yarn vscode-dts dev",
+    "package": "yarn vsce package --yarn --allow-star-activation"
   },
   "devDependencies": {
+    "@vscode/vsce": "^2.22.0",
+    "vscode-dts": "^0.3.3",
     "@parcel/watcher": "^2.1.0",
     "@tsconfig/svelte": "^2.0.0",
     "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "dependencies": {
     "glob": "^8.1.0"
   },
+  "devDependencies": {
+    "@vscode/vsce": "^2.22.0",
+    "ovsx": "^0.8.3"
+  },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
     "compile:gitpod-shared": "yarn --cwd gitpod-shared compile",


### PR DESCRIPTION
- Add `--ignore-scripts` flag to yarn install in .gitpod.yml and GitHub workflows
- Replace `npx vsce`/`npx ovsx` with `yarn vsce`/`yarn ovsx`
- Add `@vscode/vsce`, `ovsx`, and `vscode-dts` as explicit devDependencies

Related to [PDE-128](https://linear.app/ona-team/issue/PDE-128/parent-issue-disabling-npm-lifecycle-scripts)