### PR TITLE
chore: pin GitHub Actions to SHA (PDE-221)

### DIFF
--- a/.github/workflows/gitpod-web-docker.yml
+++ b/.github/workflows/gitpod-web-docker.yml
@@ -6,19 +6,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Auth Google Cloud SDK
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # pin@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # pin@v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Set up Docker
         run: |
           gcloud auth configure-docker --quiet
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # pin@v4
         with:
           node-version: 20
           cache: 'yarn'
@@ -43,7 +43,7 @@ jobs:
           yarn --cwd gitpod-web/ inject-commit-hash
 
       - name: Docker build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # pin@v6
         with:
           push: true
           context: gitpod-web
@@ -60,11 +60,11 @@ jobs:
 
       - name: Get previous job's status
         id: lastrun
-        uses: filiptronicek/get-last-job-status@main
+        uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
 
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/release-gitpod-remote.yml
+++ b/.github/workflows/release-gitpod-remote.yml
@@ -7,9 +7,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # pin@v4
         with:
           node-version: 20
 


### PR DESCRIPTION
Pin all external GitHub Actions to specific commit SHAs for supply chain security.

## Changes

- `actions/checkout@v4` → pinned to SHA
- `actions/setup-node@v4` → pinned to SHA
- `docker/build-push-action@v6` → pinned to SHA
- `filiptronicek/get-last-job-status@main` → pinned to SHA
- `google-github-actions/auth@v2` → pinned to SHA
- `google-github-actions/setup-gcloud@v2` → pinned to SHA
- `rtCamp/action-slack-notify@v2` → pinned to SHA

## Related

- Part of [PDE-138](https://linear.app/ona-team/issue/PDE-138)
- Closes [PDE-221](https://linear.app/ona-team/issue/PDE-221)